### PR TITLE
Add empty view and content on project

### DIFF
--- a/solutions/devsprint-eduardo-bocato-1/SpaceApp.xcodeproj/project.pbxproj
+++ b/solutions/devsprint-eduardo-bocato-1/SpaceApp.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		98BDC98D2784F928003820AD /* SpaceXAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BDC98C2784F928003820AD /* SpaceXAPIClient.swift */; };
 		98BDC98F2784F9D1003820AD /* AllLaunchesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BDC98E2784F9D1003820AD /* AllLaunchesResponse.swift */; };
 		E50FB67F27D602F700DFD1DD /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E50FB67E27D602F700DFD1DD /* HomeViewModel.swift */; };
+		F37BA22727D8E2B800C03F99 /* EmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F37BA22627D8E2B800C03F99 /* EmptyView.swift */; };
+		F37BA22927D8E84B00C03F99 /* ContentInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F37BA22827D8E84B00C03F99 /* ContentInfoView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -51,6 +53,8 @@
 		98BDC98E2784F9D1003820AD /* AllLaunchesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllLaunchesResponse.swift; sourceTree = "<group>"; };
 		98BDC9902784FBFC003820AD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E50FB67E27D602F700DFD1DD /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
+		F37BA22627D8E2B800C03F99 /* EmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyView.swift; sourceTree = "<group>"; };
+		F37BA22827D8E84B00C03F99 /* ContentInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentInfoView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -186,20 +190,11 @@
 		E50FB66F27D5FF5F00DFD1DD /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				F37BA22427D8E29800C03F99 /* Components */,
 				E50FB67227D5FF7300DFD1DD /* Extensions */,
 				E50FB67127D5FF6A00DFD1DD /* DesignSystem */,
-				E50FB67027D5FF6500DFD1DD /* Components */,
 			);
 			path = UI;
-			sourceTree = "<group>";
-		};
-		E50FB67027D5FF6500DFD1DD /* Components */ = {
-			isa = PBXGroup;
-			children = (
-				E50FB68427D6150E00DFD1DD /* Views */,
-				E50FB68327D6150600DFD1DD /* Buttons */,
-			);
-			path = Components;
 			sourceTree = "<group>";
 		};
 		E50FB67127D5FF6A00DFD1DD /* DesignSystem */ = {
@@ -319,20 +314,6 @@
 			path = AllLaunches;
 			sourceTree = "<group>";
 		};
-		E50FB68327D6150600DFD1DD /* Buttons */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Buttons;
-			sourceTree = "<group>";
-		};
-		E50FB68427D6150E00DFD1DD /* Views */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Views;
-			sourceTree = "<group>";
-		};
 		E50FB68627D617BC00DFD1DD /* DevpassExample-APIClient */ = {
 			isa = PBXGroup;
 			children = (
@@ -340,6 +321,23 @@
 				98BDC98C2784F928003820AD /* SpaceXAPIClient.swift */,
 			);
 			path = "DevpassExample-APIClient";
+			sourceTree = "<group>";
+		};
+		F37BA22427D8E29800C03F99 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				F37BA22527D8E2A300C03F99 /* Views */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		F37BA22527D8E2A300C03F99 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				F37BA22627D8E2B800C03F99 /* EmptyView.swift */,
+				F37BA22827D8E84B00C03F99 /* ContentInfoView.swift */,
+			);
+			path = Views;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -443,12 +441,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				98B551712784D78900AC9086 /* HomeScene.swift in Sources */,
+				F37BA22727D8E2B800C03F99 /* EmptyView.swift in Sources */,
 				E50FB67F27D602F700DFD1DD /* HomeViewModel.swift in Sources */,
 				98BDC9852784F880003820AD /* HTTPHeaderField.swift in Sources */,
 				98B5516F2784D78900AC9086 /* SpaceAppApp.swift in Sources */,
 				98BDC9832784F86F003820AD /* HTTPClient.swift in Sources */,
 				98BDC98B2784F8B5003820AD /* HTTPMethod.swift in Sources */,
 				98BDC9892784F891003820AD /* NetworkClient.swift in Sources */,
+				F37BA22927D8E84B00C03F99 /* ContentInfoView.swift in Sources */,
 				98BDC9872784F888003820AD /* Response.swift in Sources */,
 				98BDC98D2784F928003820AD /* SpaceXAPIClient.swift in Sources */,
 				98BDC9812784F865003820AD /* ContentType.swift in Sources */,

--- a/solutions/devsprint-eduardo-bocato-1/SpaceApp/Modules/Core/UI/Components/Views/ContentInfoView.swift
+++ b/solutions/devsprint-eduardo-bocato-1/SpaceApp/Modules/Core/UI/Components/Views/ContentInfoView.swift
@@ -37,6 +37,13 @@ struct ContentInfoView_Previews: PreviewProvider {
             text: "Something wrong, it's empty!",
             retryAction: {}
         )
+        .preferredColorScheme(.light)
+
+        ContentInfoView(
+            text: "Something wrong, it's empty!",
+            retryAction: {}
+        )
+        .preferredColorScheme(.dark)
     }
 }
 

--- a/solutions/devsprint-eduardo-bocato-1/SpaceApp/Modules/Core/UI/Components/Views/ContentInfoView.swift
+++ b/solutions/devsprint-eduardo-bocato-1/SpaceApp/Modules/Core/UI/Components/Views/ContentInfoView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+public struct ContentInfoView: View {
+    private let text: String
+    private let retryAction: (() -> Void)?
+
+    public init(
+        text: String,
+        retryAction: (() -> Void)? = nil
+    ) {
+        self.text = text
+        self.retryAction = retryAction
+    }
+
+    public var body: some View {
+        VStack {
+            Spacer()
+            Text(text)
+            if let retryAction = retryAction {
+                Button("Retry") {
+                    retryAction()
+                }
+                .foregroundColor(.white)
+                .padding()
+                .background(Color.blue)
+                .cornerRadius(8)
+            }
+            Spacer()
+        }
+    }
+}
+
+#if DEBUG
+struct ContentInfoView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentInfoView(
+            text: "Something wrong, it's empty!",
+            retryAction: {}
+        )
+    }
+}
+
+#endif

--- a/solutions/devsprint-eduardo-bocato-1/SpaceApp/Modules/Core/UI/Components/Views/EmptyView.swift
+++ b/solutions/devsprint-eduardo-bocato-1/SpaceApp/Modules/Core/UI/Components/Views/EmptyView.swift
@@ -19,6 +19,9 @@ public struct EmptyView: View {
 struct EmptyView_Previews: PreviewProvider {
     static var previews: some View {
         EmptyView(text: "Something wrong, it's empty!")
+            .preferredColorScheme(.light)
+        EmptyView(text: "Something wrong, it's empty!")
+            .preferredColorScheme(.dark)
     }
 }
 #endif

--- a/solutions/devsprint-eduardo-bocato-1/SpaceApp/Modules/Core/UI/Components/Views/EmptyView.swift
+++ b/solutions/devsprint-eduardo-bocato-1/SpaceApp/Modules/Core/UI/Components/Views/EmptyView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+public struct EmptyView: View {
+    private let text: String
+
+    public init(text: String) {
+        self.text = text
+    }
+
+    public var body: some View {
+        ContentInfoView(
+            text: text,
+            retryAction: nil
+        )
+    }
+}
+
+#if DEBUG
+struct EmptyView_Previews: PreviewProvider {
+    static var previews: some View {
+        EmptyView(text: "Something wrong, it's empty!")
+    }
+}
+#endif
+


### PR DESCRIPTION
### Description of the new feature
 Create a empty view for project and a ContentView to separate and componentize and be used throughout the project.
 
### Checklist:
Put an ```x``` in the boxes that apply:
- [x] Doesn't add duplicate code
- [x] Doesn't add duplicate code
- [x] Doesnt contain WIP code
 
### Evidence:
 | iPhone 12  |

| ![Captura de Tela 2022-03-09 às 12 04 00](https://user-images.githubusercontent.com/4513004/157468706-2841fbfb-6408-420f-a3ad-b929f6a14af9.png)
|